### PR TITLE
feat: Add tasks for other memray and scalene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,5 +162,6 @@ cython_debug/
 .pixi
 *.egg-info
 
-# Ignore .dat files
+# Ignore .dat files and other output
 *.dat
+output/

--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,9 @@ cython_debug/
 .pixi
 *.egg-info
 
-# Ignore .dat files and other output
+# Ignore output files
 *.dat
+*.png
 output/
+profile.html
+profile.json

--- a/pixi.toml
+++ b/pixi.toml
@@ -53,8 +53,19 @@ mprof plot --output figures/uproot_dask_memory_mprof.png
 [feature.memray.dependencies]
 memray = ">=1.12.0,<1.13"
 
+[feature.memray.tasks]
+memray-uproot-dask = """
+memray run --output memray_output/uproot_dask.bin examples/uproot_dask_memory.py && \
+memray flamegraph memray_output/uproot_dask.bin
+"""
+
 [feature.scalene.dependencies]
 scalene = ">=1.5.39,<1.6"
+
+[feature.scalene.tasks]
+scalene-uproot-dask = """
+scalene examples/uproot_dask_memory.py
+"""
 
 [environments]
 # all environments include the default feature

--- a/pixi.toml
+++ b/pixi.toml
@@ -55,8 +55,8 @@ memray = ">=1.12.0,<1.13"
 
 [feature.memray.tasks]
 memray-uproot-dask = """
-memray run --output memray_output/uproot_dask.bin examples/uproot_dask_memory.py && \
-memray flamegraph memray_output/uproot_dask.bin
+memray run --output output/uproot_dask.bin examples/uproot_dask_memory.py && \
+memray flamegraph output/uproot_dask.bin
 """
 
 [feature.scalene.dependencies]
@@ -64,7 +64,7 @@ scalene = ">=1.5.39,<1.6"
 
 [feature.scalene.tasks]
 scalene-uproot-dask = """
-scalene examples/uproot_dask_memory.py
+scalene --outfile output/uproot_dask_scalene.html examples/uproot_dask_memory.py
 """
 
 [environments]


### PR DESCRIPTION
* Add pixi tasks for profiling examples/uproot_dask_memory.py for
  memray and scalene.
* Add gitkeep for output directory.
* Ignore additional output files.